### PR TITLE
Used the endlines stored in files for tslint:disable-next-line fixes

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -238,7 +238,7 @@ export class TSLintPlugin {
             changes: [{
                 fileName,
                 textChanges: [{
-                    newText: `// tslint:disable-next-line:${problem.getRuleName()}\n`,
+                    newText: `// tslint:disable-next-line:${problem.getRuleName()}${file.endOfFileToken.getFullText()}`,
                     span: { start: file.getLineStarts()[problem.getStartPosition().getLineAndCharacter().line], length: 0 },
                 }],
             }],


### PR DESCRIPTION
We can't assume `\n` endlines because of Windows.

Fixes #9