### PR TITLE
Separated failure utility functions out from Runner

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -5,6 +5,7 @@ import { ConfigFileWatcher } from './configFileWatcher';
 import { Logger } from './logger';
 import { RunResult, TsLintRunner } from './runner';
 import { Settings, loadSettingsFromPluginConfig, loadSettingsFromTsConfig } from './settings';
+import { getNonOverlappingReplacements, filterProblemsForFile } from './runner/failures';
 
 class FailureMap {
     private readonly _map = new Map<string, tslint.RuleFailure>();
@@ -127,7 +128,7 @@ export class TSLintPlugin {
                     });
                 }
 
-                const tslintProblems = this.runner.filterProblemsForFile(fileName, result.lintResult.failures);
+                const tslintProblems = filterProblemsForFile(fileName, result.lintResult.failures);
                 for (const problem of tslintProblems) {
                     diagnostics.push(this.makeDiagnostic(problem, file));
                     this.recordCodeAction(problem, file);
@@ -237,7 +238,7 @@ export class TSLintPlugin {
     }
 
     private addAllAutoFixable(fixes: ts_module.CodeAction[], documentFixes: FailureMap, fileName: string) {
-        const allReplacements = this.runner.getNonOverlappingReplacements(Array.from(documentFixes.values()));
+        const allReplacements = getNonOverlappingReplacements(Array.from(documentFixes.values()));
         fixes.push({
             description: `Fix all auto-fixable tslint failures`,
             changes: [{

--- a/src/runner/failures.ts
+++ b/src/runner/failures.ts
@@ -1,0 +1,65 @@
+import { normalize } from 'path';
+import * as tslint from 'tslint'; // this is a dev dependency only
+
+/**
+ * Filter failures for the given document
+ */
+export function filterProblemsForFile(
+    filePath: string,
+    failures: tslint.RuleFailure[],
+): tslint.RuleFailure[] {
+    const normalizedPath = normalize(filePath);
+    // we only show diagnostics targetting this open document, some tslint rule return diagnostics for other documents/files
+    const normalizedFiles = new Map<string, string>();
+    return failures.filter(each => {
+        const fileName = each.getFileName();
+        if (!normalizedFiles.has(fileName)) {
+            normalizedFiles.set(fileName, normalize(fileName));
+        }
+        return normalizedFiles.get(fileName) === normalizedPath;
+    });
+}
+
+export function getReplacements(fix: tslint.Fix | undefined): tslint.Replacement[] {
+    let replacements: tslint.Replacement[] | null = null;
+    // in tslint4 a Fix has a replacement property with the Replacements
+    if ((fix as any).replacements) {
+        // tslint4
+        replacements = (fix as any).replacements;
+    } else {
+        // in tslint 5 a Fix is a Replacement | Replacement[]
+        if (!Array.isArray(fix)) {
+            replacements = [fix as any];
+        } else {
+            replacements = fix;
+        }
+    }
+    return replacements || [];
+}
+
+function getReplacement(failure: tslint.RuleFailure, at: number): tslint.Replacement {
+    return getReplacements(failure.getFix())[at];
+}
+
+export function sortFailures(failures: tslint.RuleFailure[]): tslint.RuleFailure[] {
+    // The failures.replacements are sorted by position, we sort on the position of the first replacement
+    return failures.sort((a, b) => {
+        return getReplacement(a, 0).start - getReplacement(b, 0).start;
+    });
+}
+
+export function getNonOverlappingReplacements(failures: tslint.RuleFailure[]): tslint.Replacement[] {
+    function overlaps(a: tslint.Replacement, b: tslint.Replacement): boolean {
+        return a.end >= b.start;
+    }
+
+    const sortedFailures = sortFailures(failures);
+    const nonOverlapping: tslint.Replacement[] = [];
+    for (let i = 0; i < sortedFailures.length; i++) {
+        const replacements = getReplacements(sortedFailures[i].getFix());
+        if (i === 0 || !overlaps(nonOverlapping[nonOverlapping.length - 1], replacements[0])) {
+            nonOverlapping.push(...replacements);
+        }
+    }
+    return nonOverlapping;
+}

--- a/src/runner/test/runner.test.ts
+++ b/src/runner/test/runner.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import 'mocha';
 import * as path from 'path';
 import { RunConfiguration, TsLintRunner } from '../index';
+import { getNonOverlappingReplacements, filterProblemsForFile } from '../failures';
 
 const testDataRoot = path.join(__dirname, '..', '..', '..', 'test-data');
 
@@ -150,7 +151,7 @@ describe('TSLintRunner', () => {
 
             expect(result.lintResult.failures.length).to.equal(1);
 
-            const filteredFailures = runner.filterProblemsForFile('does-not-exist', result.lintResult.failures);
+            const filteredFailures = filterProblemsForFile('does-not-exist', result.lintResult.failures);
             expect(filteredFailures.length).to.equal(0);
         });
     });
@@ -163,7 +164,7 @@ describe('TSLintRunner', () => {
 
             expect(result.lintResult.failures.length).to.equal(2);
 
-            const noOverlappingReplacements = runner.getNonOverlappingReplacements(result.lintResult.failures);
+            const noOverlappingReplacements = getNonOverlappingReplacements(result.lintResult.failures);
             expect(noOverlappingReplacements.length).to.equal(1);
         });
     });


### PR DESCRIPTION
Simplifies `src/plugin.ts` a bit by moving the pieces of this mostly-standalone logic to their own files.

Continues #6.