### PR TITLE
Always show disable rule fix

### DIFF
--- a/test-workspace/.vscode/settings.json
+++ b/test-workspace/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "typescript.tsdk": "node_modules/typescript/lib"
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "tslint.enable": false
 }

--- a/test-workspace/examples/eval.ts
+++ b/test-workspace/examples/eval.ts
@@ -1,0 +1,3 @@
+// There is no TSLint fix for the "no-eval" rule,
+// but the "disable rule" fix is still available.
+let x = eval("1 + 1");


### PR DESCRIPTION
Fixes #22.

_This is a port of https://github.com/angelozerr/tslint-language-service/pull/87._

These changes allow the "disable rule for the next line" fix to be shown when there are no other fixes available.

Basically, instead of only recording a failure if it can be fixed, the failure is always recorded along with a boolean that indicates whether it can be fixed. Then, anywhere that was previously looking at the recorded failures (which were always fixable) will filter the failures so that it only uses the fixable failures. The only exception to this is when adding the "disable rule for the next line" fix. It will add the fix regardless of whether the failure is fixable.

I've also renamed any variables called problem to failure to avoid any confusion about whether it's a `tslint.RuleFailure` or the new `Problem` interface I created, which is why there seems to be a lot of changes. 

I've split the changes into separate commits to make it easier to see where I've actually change the logic. The first commit contains the actual change to get the "disable rule" quick fix to appear. The second commit contains all of the renaming.