### PR TITLE
Prepare for better fix on save

### DIFF
--- a/e2e/tests/codeFixes.test.js
+++ b/e2e/tests/codeFixes.test.js
@@ -47,7 +47,7 @@ describe('CodeFixes', () => {
         assert.isTrue(errorResponse.success);
         assert.deepEqual(errorResponse.body, [
             {
-                "fixName": "",
+                "fixName": "tslint:array-type",
                 "description": "Fix: Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.",
                 "changes": [
                     {
@@ -80,7 +80,7 @@ describe('CodeFixes', () => {
                 ]
             },
             {
-                "fixName": "",
+                "fixName": "tslint:fix-all",
                 "description": "Fix all auto-fixable tslint failures",
                 "changes": [
                     {
@@ -113,7 +113,7 @@ describe('CodeFixes', () => {
                 ]
             },
             {
-                "fixName": "",
+                "fixName": "tslint:disable:array-type",
                 "description": "Disable rule 'array-type'",
                 "changes": [
                     {
@@ -137,7 +137,7 @@ describe('CodeFixes', () => {
         ]);
     });
 
-    it('should return individual fixes and fix all for multuple errors of same type in file', async () => {
+    it('should return individual fixes and fix all for multiple errors of same type in file', async () => {
         const errorResponse = await getCodeFixes(
             `let x: Array<string> = new Array<string>(); console.log(x);\nlet y: Array<string> = new Array<string>(); console.log(y);`, {
                 startLine: 1,
@@ -151,7 +151,7 @@ describe('CodeFixes', () => {
 
         assert.deepEqual(errorResponse.body, [
             {
-                "fixName": "",
+                "fixName": "tslint:array-type",
                 "description": "Fix: Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.",
                 "changes": [
                     {
@@ -185,7 +185,7 @@ describe('CodeFixes', () => {
             },
             {
                 "description": "Fix all 'array-type'",
-                "fixName": "",
+                "fixName": "tslint:fix-all:array-type",
                 "changes": [
                     {
                         "fileName": mockFileName,
@@ -244,7 +244,7 @@ describe('CodeFixes', () => {
                 ]
             },
             {
-                "fixName": "",
+                "fixName": "tslint:fix-all",
                 "description": "Fix all auto-fixable tslint failures",
                 "changes": [
                     {
@@ -299,7 +299,7 @@ describe('CodeFixes', () => {
                 ]
             },
             {
-                "fixName": "",
+                "fixName": "tslint:disable:array-type",
                 "description": "Disable rule 'array-type'",
                 "changes": [
                     {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -218,7 +218,7 @@ export class TSLintPlugin {
     private getRuleFailureQuickFix(failure: tslint.RuleFailure, fileName: string): ts_module.CodeFixAction {
         return {
             description: `Fix: ${failure.getFailure()}`,
-            fixName: '',
+            fixName: `tslint:${failure.getRuleName()}`,
             changes: [failureToFileTextChange(failure, fileName)],
         };
     }
@@ -244,7 +244,7 @@ export class TSLintPlugin {
 
         return {
             description: `Fix all '${ruleName}'`,
-            fixName: '',
+            fixName: `tslint:fix-all:${ruleName}`,
             changes,
         };
     }
@@ -252,7 +252,7 @@ export class TSLintPlugin {
     private getDisableRuleQuickFix(failure: tslint.RuleFailure, fileName: string, file: ts_module.SourceFile): ts_module.CodeFixAction {
         return {
             description: `Disable rule '${failure.getRuleName()}'`,
-            fixName: '',
+            fixName: `tslint:disable:${failure.getRuleName()}`,
             changes: [{
                 fileName,
                 textChanges: [{
@@ -267,7 +267,7 @@ export class TSLintPlugin {
         const allReplacements = getNonOverlappingReplacements(Array.from(documentFixes.values()).filter(x => x.fixable).map(x => x.failure));
         return {
             description: `Fix all auto-fixable tslint failures`,
-            fixName: '',
+            fixName: `tslint:fix-all`,
             changes: [{
                 fileName,
                 textChanges: allReplacements.map(convertReplacementToTextChange),


### PR DESCRIPTION
This pull request sets the fixName property of code fix actions. This way if somebody gets the list of available code fixes, it can identify the ones added by tslint and will be able to see which rule produced them.

After the PR is merged, it will be possible to implement the full `tslint.autoFixOnSave` feature of [vscode-tslint](https://github.com/Microsoft/vscode-tslint) extension in the new [vscode-typescript-tslint-plugin](https://github.com/Microsoft/vscode-typescript-tslint-plugin). Otherwise the only way is to parse the descriptions of quick fixes to extract the rule name, which would be very error-prone and ugly.

See the last item in #1 todo list for @mjbvz.

Related:

 - Microsoft/vscode-typescript-tslint-plugin/issues/2
 - Microsoft/vscode-typescript-tslint-plugin/issues/43
 - https://github.com/Microsoft/vscode-tslint/issues/417
 - #29
