### PR TITLE
correction to Windows to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ matrix:
     - os: mac
     - os: windows
 
+before_install:
+  - yarn config delete proxy
+  - npm config rm proxy
+  - npm config rm https-proxy
+  
 install:
   - npm install 
   - (cd e2e ; npm install)


### PR DESCRIPTION
correction to windows to Travis build : 

as per: https://travis-ci.community/t/yarn-failed-on-windows-os-environment/591/2
@joshuef  => 
so, removing yarn.lock and then

before_install:
  - yarn config delete proxy
  - npm config rm proxy
  - npm config rm https-proxy
got this working for us! I’m not sure if yarn.lock removal is necessary. I’m testing that out now.

---
the previous build has failed ( # 51.3 errored) :  

No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
The build has been terminated