### PR TITLE
disabling yarn gpg in Travis to fix hanging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ language: node_js
 
 node_js:
   - '9'
-  - lts/*
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
     - os: linux
     - os: mac
     - os: windows
+    
 env:
   - YARN_GPG=no
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: node_js
 
 node_js:
   - '9'
+  - lts/*
 
 sudo: false
 
@@ -14,7 +15,9 @@ matrix:
     - os: linux
     - os: mac
     - os: windows
-
+env:
+  - YARN_GPG=no
+  
 install:
   - npm install 
   - (cd e2e ; npm install)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ See [editor support](#editor-support) for more detailed setup instructions.
  * `alwaysShowRuleFailuresAsWarnings` - Always show rule failures as warnings, ignoring the severity configuration in the tslint.json configuration. Default is `true`.
  * `suppressWhileTypeErrorsPresent` - Suppress tslint errors from being reported while other errors are present.
  * `exclude` - List of files to exclude from tslint.
- * `mockTypeScriptVersion` - Force tslint to use the same version of TypeScript as this plugin. This will affect other plugins that require the typescript package.
 	
  
 Here is a configuration sample:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ See [editor support](#editor-support) for more detailed setup instructions.
  * `alwaysShowRuleFailuresAsWarnings` - Always show rule failures as warnings, ignoring the severity configuration in the tslint.json configuration. Default is `true`.
  * `suppressWhileTypeErrorsPresent` - Suppress tslint errors from being reported while other errors are present.
  * `exclude` - List of files to exclude from tslint.
+ * `mockTypeScriptVersion` - Force tslint to use the same version of TypeScript as this plugin. This will affect other plugins that require the typescript package.
+	
  
 Here is a configuration sample:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ See [editor support](#editor-support) for more detailed setup instructions.
  * `alwaysShowRuleFailuresAsWarnings` - Always show rule failures as warnings, ignoring the severity configuration in the tslint.json configuration. Default is `true`.
  * `suppressWhileTypeErrorsPresent` - Suppress tslint errors from being reported while other errors are present.
  * `exclude` - List of files to exclude from tslint.
-	
  
 Here is a configuration sample:
 


### PR DESCRIPTION
disabling yarn gpg in Travis to fix windows hanging

as per  https://travis-ci.community/t/build-doesnt-finish-after-completing-tests/288/9

Oct '18
@AviVahl
Checked it without my before_install. Still got stuck. It appears the yarn installation (and pgp verification) occurs anyway, because my repo contains a yarn.lock.

The repo is setup using yarn workspaces, so I have no proper matching alternative in npm land yet. :frowning:

EDIT:
tried setting env variable YARN_GPG=no (via [Travis's] configuration) to force no gpg validation, but the container appears to be stuck on: Worker information

I’ve used secure env tokens (via Travis config- “hide from log”), which seems to be broken with Windows containers. Trying regular env var to see if [the] behavior is different.

EDIT:
Yes! It was the gpg that install.sh of yarn runs. Build now passes, after setting the YARN_GPG=no environment variable.

----

and as per : https://travis-ci.community/t/build-doesnt-finish-after-completing-tests/288/13

Oct '18
josh (@joshk) Josh Kalderimis
Travis CI Staff (Head of Product at @travis-ci)


Hi @chrisdothtml

Could you please try adding YARN_GPG=no to your .travis.yml config to see if this helps?

@BanzaiMan do we currently detect and kill rogue processes when a build finishes?