### PR TITLE
Wrap global tslint lookup in try/catch

### DIFF
--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -249,13 +249,12 @@ export class TsLintRunner {
 
         let globalTSLintPath: string | undefined;
         try {
-            globalTSLintPath = this.resolveTsLint({ nodePath: undefined, cwd: globalPath });
+            globalTSLintPath = this.resolveTsLint({ nodePath: undefined, cwd: globalPath })
+                || this.resolveTsLint({ nodePath: globalPath, cwd: globalPath });
         } catch {
             // noop
         }
-        if (!globalTSLintPath) {
-            globalTSLintPath = this.resolveTsLint({ nodePath: globalPath, cwd: globalPath });
-        }
+
         return { workspaceTsLintPath, globalTsLintPath: globalTSLintPath };
     }
 


### PR DESCRIPTION
As discovered in the issue https://github.com/microsoft/vscode-typescript-tslint-plugin/issues/138, if a user has `~/.npmrc#prefix` set but no global binary for `tslint` installed, the global tslint lookups will fail. Currently the first global lookup will fail but is wrapped in a try/catch, so the subsequent `if` branch will execute. In that case though, the second global lookup fails but is _not_ wrapped in a try catch.

This PR collapses both global lookups into an `||` guard so that they're both wrapped in try/catch. This now works when prefix is set.

/cc @mjbvz 